### PR TITLE
Delegated subnet association & required components

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Below is an example of the module in use.
 
 ```terraform
   module "skaylink-flexible-mysql" {
+    source                = "skaylink/skaylink-flexible-mysql/azurerm"
+    version               = "1.0.0"
     resource_group_name   = "my-project-rg"
     usecase               = "my-use-case-that-is-less-than-50-characters"
     location              = "norwayeast"
@@ -32,6 +34,8 @@ This is an example of how this may look:
 
 ```terraform
   module "skaylink-flexible-mysql" {
+    source                              = "skaylink/skaylink-flexible-mysql/azurerm"
+    version                             = "1.0.0"
     resource_group_name                 = "my-project-rg"
     usecase                             = "my-use-case-that-is-less-than-50-characters"
     location                            = "norwayeast"

--- a/README.md
+++ b/README.md
@@ -22,3 +22,31 @@ Below is an example of the module in use.
     administrator_login   = "iamgroot"
   }
 ```
+
+If you want to assign a delegated subnet, this will also create a virtual network link, and a private DNS zone.
+
+Once you populate `delegated_subnet_name`, the following values must also be populated: `virtual_network_name`, `virtual_network_resource_group_name` and `private_dns_zone_name`.
+
+This is an example of how this may look:
+
+
+```terraform
+  module "skaylink-flexible-mysql" {
+    resource_group_name                 = "my-project-rg"
+    usecase                             = "my-use-case-that-is-less-than-50-characters"
+    location                            = "norwayeast"
+    environment                         = "dev"
+    key_vault_name                      = "my-kv-name"
+    mgmt_resource_group                 = "my-kv-resource-group"
+    backup_retention_days               = 35
+    size_gb                             = "20"
+    sku                                 = "MO_Standard_E2ds_v5"
+    zone_redundant                      = true
+    databases                           = ["my-awesome-db-1", "my-awesome-db-2", "my-awesome-db-3"]
+    administrator_login                 = "iamgroot"
+    delegated_subnet_name               = "thenameofmydelegatedsubnet"
+    virtual_network_name                = "myvnet"
+    virtual_network_resource_group_name = "my-vnet-rg"
+    private_dns_zone_name               = "myprivatednszoneprefix"
+  }
+```

--- a/datasource.tf
+++ b/datasource.tf
@@ -24,3 +24,16 @@ data "azurerm_key_vault" "kv" {
   name                = var.key_vault_name
   resource_group_name = var.mgmt_resource_group
 }
+
+data "azurerm_virtual_network" "vnet" {
+  count               = var.delegated_subnet_name != null ? 1 : 0
+  name                = var.virtual_network_name
+  resource_group_name = var.virtual_network_resource_group_name
+}
+
+data "azurerm_subnet" "subnet" {
+  count                = var.delegated_subnet_name != null ? 1 : 0
+  name                 = var.delegated_subnet_name
+  virtual_network_name = var.virtual_network_name
+  resource_group_name  = var.virtual_network_resource_group_name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -152,3 +152,27 @@ variable "administrator_login" {
     error_message = "Invalid value, valid characters are A-Z, a-z, 0-9 and hyphens"
   }
 }
+
+variable "virtual_network_resource_group_name" {
+  type        = string
+  default     = null
+  description = "The name of the resource group containing the virtual network with your delegated subnet"
+}
+
+variable "virtual_network_name" {
+  type        = string
+  default     = null
+  description = "The name of the VNET where your delegated subnet is located"
+}
+
+variable "delegated_subnet_name" {
+  type        = string
+  default     = null
+  description = "The name of the delegated subnet to assign the service to"
+}
+
+variable "private_dns_zone_name" {
+  type        = string
+  default     = null
+  description = "The name of your new private DNS zone"
+}


### PR DESCRIPTION
- Allows you to assign the resource to a delegated subnet
- Creates a Private DNS Zone if you assign a delegated subnet
- Creates a VNET link if you assign a delegated subnet
- These new parameters are all optional _unless_ you populate `delegated_subnet_name` at which point both `private_dns_zone_name`, `virtual_network_resource_group_name` and `virtual_network_name` become mandatory.

Happy to hear opinions on a more elegant solution to this tbh, as it does bring some caveats.